### PR TITLE
Update Byte of Python book

### DIFF
--- a/free-programming-books.md
+++ b/free-programming-books.md
@@ -1741,7 +1741,7 @@ For resources on Angular, Backbone, D3, Dojo, Ember, Express, jQuery, Knockout, 
 * [Biopython](http://biopython.org/DIST/docs/tutorial/Tutorial.pdf) (PDF)
 * [Building Skills in Object-Oriented Design (Python)](http://www.itmaybeahack.com/book/oodesign-python-2.1/latex/BuildingSkillsinOODesign.pdf) (PDF) (2.1.1)
 * [Building Skills in Python](http://www.itmaybeahack.com/book/python-2.6/latex/BuildingSkillsinPython.pdf) (PDF) (2.6)
-* [Byte of Python](http://www.swaroopch.com/notes/python/) (2.7.x)
+* [Byte of Python](http://python.swaroopch.com/) (3.5.1)
 * [Code Like a Pythonista: Idiomatic Python](http://python.net/~goodger/projects/pycon/2007/idiomatic/handout.html)
 * [CodeCademy Python](https://www.codecademy.com/learn/python)
 * [Composing Programs](http://composingprograms.com) (3.x)


### PR DESCRIPTION
Byte of Python link and version updated

http://www.swaroopch.com/notes/python/ => http://python.swaroopch.com/
(2.7.x) => (3.5.1)

Version is mentioned here: http://python.swaroopch.com/installation.html